### PR TITLE
Add GH_PAT workflow note

### DIFF
--- a/.github/workflows/update-commits.yml
+++ b/.github/workflows/update-commits.yml
@@ -1,3 +1,5 @@
+# GH_PAT must be set in repository secrets for this workflow to push changes
+
 name: Update Commits JSON
 
 on:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# jurietto.github.io
+
+This repository hosts the data and workflow used to update `commits.json`. The workflow requires a personal access token to push changes back to the repository.
+
+## Setup
+
+1. Create a [GitHub Personal Access Token](https://github.com/settings/tokens) with repo permissions.
+2. Add the token as a repository secret named `GH_PAT` (`Settings` -> `Secrets` -> `Actions`).
+3. The `update-commits.yml` workflow will use this token to push updates to `commits.json`.
+


### PR DESCRIPTION
## Summary
- note that the workflow needs GH_PAT secret to push
- document the setup requirement in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684cf08548908323b7be14cf717fe08d