### PR TITLE
Fix commit date parsing for Safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,13 +56,23 @@ function displayRecentCommits() {
       commitsTableBody.innerHTML = '';
       
       // Sort commits by date (newest first) and take the first 5
-      const sortedCommits = commits.sort((a, b) => new Date(b.date) - new Date(a.date));
+      const parseCommitDate = dateStr => {
+        const iso = dateStr
+          .replace(' ', 'T')
+          .replace(/ ([+-]\d{2})(\d{2})$/, (_, h, m) => ` ${h}:${m}`)
+          .replace('T', 'T');
+        return new Date(iso);
+      };
+
+      const sortedCommits = commits.sort((a, b) =>
+        parseCommitDate(b.date) - parseCommitDate(a.date)
+      );
       const recentCommits = sortedCommits.slice(0, 5);
 
       recentCommits.forEach(commit => {
         const row = document.createElement('tr');
         row.innerHTML = `
-          <td>${new Date(commit.date).toLocaleString()}</td>
+          <td>${parseCommitDate(commit.date).toLocaleString()}</td>
           <td>${commit.author}</td>
           <td>${commit.message}</td>
         `;


### PR DESCRIPTION
## Summary
- handle `YYYY-MM-DD HH:mm:ss -ZZZZ` timestamps so mobile Safari doesn't show `Invalid Date`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68534b3e088483238448e4c69d9aa501