### PR TITLE
Fix commit date parsing for Safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,13 +56,23 @@ function displayRecentCommits() {
       commitsTableBody.innerHTML = '';
       
       // Sort commits by date (newest first) and take the first 5
-      const sortedCommits = commits.sort((a, b) => new Date(b.date) - new Date(a.date));
+      const parseCommitDate = dateStr => {
+        const parts = dateStr.trim().split(' ');
+        if (parts.length < 2) return new Date(dateStr);
+        const [date, time, zone] = parts;
+        const offset = zone ? zone.replace(/([+-]\d{2})(\d{2})/, '$1:$2') : '';
+        return new Date(`${date}T${time}${offset}`);
+      };
+
+      const sortedCommits = commits.sort((a, b) =>
+        parseCommitDate(b.date) - parseCommitDate(a.date)
+      );
       const recentCommits = sortedCommits.slice(0, 5);
 
       recentCommits.forEach(commit => {
         const row = document.createElement('tr');
         row.innerHTML = `
-          <td>${new Date(commit.date).toLocaleString()}</td>
+          <td>${parseCommitDate(commit.date).toLocaleString()}</td>
           <td>${commit.author}</td>
           <td>${commit.message}</td>
         `;

--- a/style.css
+++ b/style.css
@@ -70,14 +70,14 @@ p, ul, table { margin-bottom: var(--element-spacing); word-wrap: break-word; ove
 /* Link Lists */
 ul.link-list { list-style: none; padding-left: 0; margin: 0 0 1em 0; }
 ul.link-list li { position: relative; padding-left: 28px; margin: 0.25em 0; min-height: 20px; }
-ul.link-list li::before { content: ""; position: absolute; left: 0; top: 50%; transform: translateY(-50%); width: 16px; height: 16px; background-image: url('https://file.garden/ZhTgSjrp5nAroRKq/098765'); background-size: contain; background-repeat: no-repeat; background-position: center; display: inline-block; }
+ul.link-list li::before { content: ""; position: absolute; left: 0; top: 0.2em; width: 16px; height: 16px; background-image: url('https://file.garden/ZhTgSjrp5nAroRKq/098765'); background-size: contain; background-repeat: no-repeat; background-position: center; display: inline-block; }
 
 ul.profile-list { list-style: disc inside; padding-left: 1em; margin: 0 0 1em 0; }
 ul.profile-list li { margin: 0.2em 0; padding: 0; line-height: 1.5; }
 
 ul.info-list { list-style: none; padding: 0; margin: 0 0 1em 0; }
 ul.info-list li { position: relative; padding-left: 28px; margin: 0.1em 0; line-height: 1.5; }
-ul.info-list li::before { content: ""; position: absolute; left: 0; top: 50%; transform: translateY(-50%); width: 20px; height: 20px; background-image: url('https://file.garden/ZhTgSjrp5nAroRKq/098765'); background-size: contain; background-repeat: no-repeat; background-position: center; display: inline-block; }
+ul.info-list li::before { content: ""; position: absolute; left: 0; top: 0.2em; width: 16px; height: 16px; background-image: url('https://file.garden/ZhTgSjrp5nAroRKq/098765'); background-size: contain; background-repeat: no-repeat; background-position: center; display: inline-block; }
 
 /* Embed Frames */
 .cbox-frame { width: 100%; overflow: hidden; height: 450px; }


### PR DESCRIPTION
## Summary
- handle `YYYY-MM-DD HH:mm:ss -ZZZZ` timestamps so mobile Safari doesn't show `Invalid Date`
- adjust custom list bullets to sit inline with text

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68534b3e088483238448e4c69d9aa501