### PR TITLE
Fix commit display

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,13 +56,7 @@ function displayRecentCommits() {
       commitsTableBody.innerHTML = '';
       
       // Sort commits by date (newest first) and take the first 5
-      const parseCommitDate = dateStr => {
-        const iso = dateStr
-          .replace(' ', 'T')
-          .replace(/ ([+-]\d{2})(\d{2})$/, (_, h, m) => ` ${h}:${m}`)
-          .replace('T', 'T');
-        return new Date(iso);
-      };
+      const parseCommitDate = dateStr => new Date(dateStr);
 
       const sortedCommits = commits.sort((a, b) =>
         parseCommitDate(b.date) - parseCommitDate(a.date)


### PR DESCRIPTION
## Summary
- fix commit date parsing so the changelog shows the latest commits

## Testing
- `node -e "const fs=require('./commits.json');"`

------
https://chatgpt.com/codex/tasks/task_e_685351f27ca083238ba80b5429b3bd77